### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 1.8.0 (May 01, 2017)
+## 1.8.1 (May 01, 2017)
 
 * Bug: Fix incorrect file name in imports [#9](https://github.com/Sertion/vscode-gitblame/issues/9) (Thanks to [@pftbest](https://github.com/pftbest))
 


### PR DESCRIPTION
[The changes listed for 1.8.1](https://github.com/Sertion/vscode-gitblame/commit/b46e280655d2f89ab2cffb7c9f421a1f5a0a01c9#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR3) were incorrectly attributed to 1.8.0.