### PR TITLE
Create web url from remote url with no .git suffix

### DIFF
--- a/src/git/blame.ts
+++ b/src/git/blame.ts
@@ -127,7 +127,7 @@ export class GitBlame {
         isPlural: boolean,
     ): string {
         return url.replace(
-            /^(git@|https:\/\/)([^:\/]+)[:\/](.*)\.git$/,
+            /^(git@|https:\/\/)([^:\/]+)[:\/](.*?)(\.git)?$/,
             `https://$2/$3/${isPlural ? "commits" : "commit"}/${hash}`,
         );
     }

--- a/test/gitblame.test.ts
+++ b/test/gitblame.test.ts
@@ -1,0 +1,30 @@
+import * as assert from "assert";
+
+import { GitBlame } from "../src/git/blame";
+
+suite("Web URL formatting", () => {
+  const blame = new GitBlame();
+
+  test("https://", () => {
+    assert.equal(
+      blame.defaultWebPath("https://example.com/user/repo.git", "hash", false),
+      "https://example.com/user/repo/commit/hash",
+    );
+    assert.equal(
+      blame.defaultWebPath("https://example.com/user/repo", "hash", false),
+      "https://example.com/user/repo/commit/hash",
+    );
+  });
+
+  test("git@", () => {
+    assert.equal(
+      blame.defaultWebPath("git@example.com:user/repo.git", "hash", false),
+      "https://example.com/user/repo/commit/hash",
+    );
+    assert.equal(
+      blame.defaultWebPath("git@example.com:user/repo", "hash", false),
+      "https://example.com/user/repo/commit/hash",
+    );
+  });
+
+});


### PR DESCRIPTION
When working with golang and the `go get` command, the repositories are being created with `origin` remote urls that are not ending with `.git`. 

When using the `git@` protocol for a repo with no .git suffix, vscode-gitblame threw an error: [UriError]: Scheme contains illegal characters.

This pull request fixes that, and adds a few tests around the behaviour.




