### PR TITLE
Add support for using remote URL in blame link expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ See Git Blame information in the status bar for the currently selected line.
             <ul>
               <li><code>${hash}</code> - the commit hash</li>
               <li><code>${project.name}</code> - your project name (e.g. <code>https://github.com/user/<strong>project_name</strong>.git</code>)</li>
+              <li><code>${project.remote}</code> - the current default remote's URL with the
+              protocol, port-specifiers, and trailing <code>.git</code> stripped. (e.g.
+              <code>https://<strong>github.com/user/project_name</strong>.git</code>)</li>
             </ul>
           </li>
           <li><em>Example:</em> <code>https://github.com/Sertion/vscode-gitblame/commit/${hash}</code></li>
+          <li><em>Example:</em> <code>https://${project.remote}/+/${hash}</code></li>
       </ul>
     </tr>
     <tr>

--- a/src/git/blame.ts
+++ b/src/git/blame.ts
@@ -284,10 +284,11 @@ export class GitBlame {
             return;
         }
 
+        const remote = this.getRemoteUrl();
         const commitUrl = Property.get("commitUrl") || "";
         const origin = await this.getOriginOfActiveFile();
         const projectName = this.projectNameFromOrigin(origin);
-        const remoteUrl = GitBlame.stripGitRemoteUrl(await this.getRemoteUrl());
+        const remoteUrl = GitBlame.stripGitRemoteUrl(await remote);
         const parsedUrl = commitUrl
             .replace(/\$\{hash\}/g, commitInfo.hash)
             .replace(/\$\{project.remote\}/g, remoteUrl)
@@ -404,7 +405,7 @@ export class GitBlame {
         });
         const curRemote = await execute(gitCommand, [
             "config",
-            "--worktree",
+            "--local",
             "--get",
             `branch.${ currentBranch.trim() }.remote`,
         ], {
@@ -412,7 +413,7 @@ export class GitBlame {
         });
         const remoteUrl = await execute(gitCommand, [
             "config",
-            "--worktree",
+            "--local",
             "--get",
             `remote.${ curRemote.trim() }.url`,
         ], {

--- a/src/git/blame.ts
+++ b/src/git/blame.ts
@@ -66,6 +66,15 @@ export class GitBlame {
         return commit.hash === HASH_NO_COMMIT_GIT;
     }
 
+    private static stripGitRemoteUrl(rawUrl: string): string {
+        const httplessUrl = rawUrl.replace(/^[a-z-]+:\/\//i, "");
+        const colonlessUrl = httplessUrl.replace(
+            /:([a-z_\.~+%-][a-z0-9_\.~+%-]+)\/?/i,
+            "/$1/",
+        );
+        return colonlessUrl.replace(/\.git$/i, "");
+    }
+
     private disposable: Disposable;
     private readonly statusBarView: StatusBarView;
     private readonly files: Map<string, GitFile> = new Map();
@@ -268,15 +277,6 @@ export class GitBlame {
         return commitInfo;
     }
 
-    private static stripGitRemoteUrl(rawUrl: string): string {
-        const httplessUrl = rawUrl.replace(/^[a-z-]+:\/\//i, "");
-        const colonlessUrl = httplessUrl.replace(
-            /:([a-z_\.~+%-][a-z0-9_\.~+%-]+)\/?/i,
-            "/$1/",
-        );
-        return colonlessUrl.replace(/\.git$/i, "");
-    }
-
     private async getToolUrl(
         commitInfo: IGitCommitInfo,
     ): Promise<Uri | undefined> {
@@ -398,7 +398,7 @@ export class GitBlame {
             "symbolic-ref",
             "-q",
             "--short",
-            "HEAD"
+            "HEAD",
         ], {
             cwd: activeFileFolder,
         });
@@ -406,7 +406,7 @@ export class GitBlame {
             "config",
             "--worktree",
             "--get",
-            `branch.${ currentBranch.trim() }.remote`
+            `branch.${ currentBranch.trim() }.remote`,
         ], {
             cwd: activeFileFolder,
         });
@@ -414,7 +414,7 @@ export class GitBlame {
             "config",
             "--worktree",
             "--get",
-            `remote.${ curRemote.trim() }.url`
+            `remote.${ curRemote.trim() }.url`,
         ], {
             cwd: activeFileFolder,
         });


### PR DESCRIPTION
For some projects one can use the remote-endpoint to create a commit
link. This adds a new token for gitblame.commitUrl '${project.remote}'
that will expand to the current-branches upstream URL with the
protocol, port-numbers, and trailing '.git' stripped off.

Test: Use git-blame with an AOSP tree and gitblame.commitUrl set to
      'https://${project.remote}/+/${hash}'.