### PR TITLE
Adding a simple auto plural detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "gitblame.commitUrl": {
           "type": "string",
           "default": "guess",
-          "description": "The link to an online tool to view a commit (use ${hash} for the commit hash). \"no\" will disable this feature."
+          "markdownDescription": "The link to an online tool to view a commit (use `${hash}` for the commit hash). `\"no\"` will disable this feature."
         },
         "gitblame.ignoreWhitespace": {
           "type": "boolean",
@@ -96,6 +96,14 @@
           "type": "boolean",
           "default": false,
           "description": "BitBucket uses commits instead of commit in their web interface. Turn this on if you want the View button to work for BitBucket."
+        },
+        "gitblame.pluralWebPathSubstrings": {
+          "type": "array",
+          "default": [
+            "bitbucket",
+            "atlassian"
+          ],
+          "markdownDescription": "An array of substrings that, when present in the git origin URL, activates `gitblame.isWebPathPlural`"
         },
         "gitblame.logLevel": {
           "type": "array",

--- a/src/git/blame.ts
+++ b/src/git/blame.ts
@@ -337,7 +337,7 @@ export class GitBlame {
         if (isWebUri(parsedUrl)) {
             return Uri.parse(parsedUrl);
         } else if (parsedUrl === "guess") {
-            const isWebPathPlural = !!Property.get("isWebPathPlural");
+            const isWebPathPlural = this.isToolUrlPlural(origin);
             if (origin) {
                 const uri = this.defaultWebPath(
                     origin,
@@ -491,5 +491,21 @@ export class GitBlame {
         return () => {
             this.files.delete(fileName);
         };
+    }
+
+    private isToolUrlPlural(origin: string): boolean {
+        const isWebPathPlural = Property.get("isWebPathPlural");
+
+        if (isWebPathPlural === true) {
+            return true;
+        }
+
+        const urlParts = Property.get("pluralWebPathSubstrings");
+
+        if (urlParts === undefined) {
+            return false;
+        }
+
+        return urlParts.some((substring) => origin.includes(substring));
     }
 }

--- a/src/util/property.ts
+++ b/src/util/property.ts
@@ -11,6 +11,7 @@ interface IPropertiesMap {
     "statusBarMessageFormat": string;
     "statusBarMessageNoCommit": string;
     "statusBarPositionPriority": number;
+    "pluralWebPathSubstrings": string[];
 }
 
 export class Property {


### PR DESCRIPTION
Checking git origin URL for one of the substrings in the new array configuration. If it does automatically set it to be a plural URL. Setting `gitblame.isWebPathPlural` to true still overrides this.