### PR TITLE
Add configuration `gitblame.remoteName`

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,12 @@
         "gitblame.inferCommitUrl": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "When enabled it inferes online commit tool URL based on origin URL. Disabled whenever `gitblame.commitUrl` isn't empty."
+          "markdownDescription": "When enabled it inferes online commit tool URL based on a remote's URL. Disabled whenever `gitblame.commitUrl` isn't empty."
+        },
+        "gitblame.remoteName": {
+          "type": "string",
+          "default": "origin",
+          "markdownDescription": "The name of the git remote used by inferCommitUrl to build the URL."
         },
         "gitblame.commitUrl": {
           "type": "string",

--- a/src/git/extension.ts
+++ b/src/git/extension.ts
@@ -277,8 +277,10 @@ export class GitExtension {
         );
 
         const remote = getRemoteUrl();
-        const commitUrl = container.resolve(Property).get("commitUrl") || "";
-        const origin = await getOriginOfActiveFile();
+        const properties = container.resolve(Property);
+        const commitUrl = properties.get("commitUrl") || "";
+        const remoteName = properties.get("remoteName") || "origin";
+        const origin = await getOriginOfActiveFile(remoteName);
         const projectName = this.projectNameFromOrigin(origin);
         const remoteUrl = stripGitRemoteUrl(await remote);
         const parsedUrl = TextDecorator.parseTokens(commitUrl, {

--- a/src/git/util/gitcommand.ts
+++ b/src/git/util/gitcommand.ts
@@ -42,7 +42,9 @@ export function getGitCommand(): string {
     }
 }
 
-export async function getOriginOfActiveFile(): Promise<string> {
+export async function getOriginOfActiveFile(
+    remoteName: string,
+): Promise<string> {
     if (!validEditor(window.activeTextEditor)) {
         return "";
     }
@@ -53,7 +55,7 @@ export async function getOriginOfActiveFile(): Promise<string> {
     const originUrl = await execute(gitCommand, [
         "ls-remote",
         "--get-url",
-        "origin",
+        remoteName,
     ], {
         cwd: activeFileFolder,
     });

--- a/src/util/property.ts
+++ b/src/util/property.ts
@@ -4,6 +4,7 @@ import { injectable } from "tsyringe";
 interface PropertiesMap {
     "inferCommitUrl": boolean;
     "commitUrl": string;
+    "remoteName": string;
     "ignoreWhitespace": boolean;
     "infoMessageFormat": string;
     "isWebPathPlural": boolean;


### PR DESCRIPTION
This new configuration property allows to specify another remote than `origin` to build the commit URL.

For example, I like to clone repositories with the remote name `upstream`, and reserve the name `origin` for the personal repository to which I can push.