### PR TITLE
Implement date token for author and committer

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,12 @@ See Git Blame information in the status bar for the currently selected line.
 | `${author.email}` | No | - | - | the commit author's e-mail |
 | `${author.timestamp}` | No | - | - | timestamp for the commit author's commit |
 | `${author.tz}` | No | - | - | the commit author's time zone |
+| `${author.date}` | No | - | - | the commit author's date (ex: 1990-09-16) |
 | `${committer.name}` | No | - | - | the committer's name |
 | `${committer.email}` | No | - | - | the committer's e-mail |
 | `${committer.timestamp}` | No | - | - | timestamp for the committer's commit |
 | `${committer.tz}` | No | - | - | the committer's time zone |
+| `${committer.date}` | No | - | - | the committer's date (ex: Sep 16 1990) |
 | `${time.ago}` | No | - | - | displays an estimation of how long ago the author committed (e.g. `10 hours ago`, `20 days ago`, `4 months ago`) |
 | `${time.c_ago}` | No | - | - | displays an estimation of how long ago the committer committed (e.g. `10 hours ago`, `20 days ago`, `4 months ago`) |
 

--- a/src/util/textdecorator.ts
+++ b/src/util/textdecorator.ts
@@ -23,6 +23,7 @@ export interface InfoTokenNormalizedCommitInfo extends InfoTokens {
     "author.name": () => string;
     "author.timestamp": () => string;
     "author.tz": () => string;
+    "author.date": () => string;
     "commit.hash": () => string;
     "commit.hash_short": (length?: string) => string;
     "commit.summary": () => string;
@@ -30,6 +31,7 @@ export interface InfoTokenNormalizedCommitInfo extends InfoTokens {
     "committer.name": () => string;
     "committer.timestamp": () => string;
     "committer.tz": () => string;
+    "committer.date": () => string;
     "time.ago": () => string;
     "time.c_ago": () => string;
     "time.c_from": () => string;
@@ -160,7 +162,9 @@ export class TextDecorator {
         }
         const ago = valueFrom(TextDecorator.toDateText(now, authorTime));
         const cAgo = valueFrom(TextDecorator.toDateText(now, committerTime));
-        const hashShort = (length = "7"): string => {
+        const authorDate = valueFrom(authorTime.toISOString().slice(0, 10));
+        const cDate = valueFrom(committerTime.toISOString().slice(0, 10));
+        const hashShort = (length = '7'): string => {
             const cutoffPoint = length.toString();
             return commit.hash.substr(
                 0,
@@ -173,6 +177,7 @@ export class TextDecorator {
             "author.name": valueFrom(commit.author.name),
             "author.timestamp": valueFrom(commit.author.timestamp),
             "author.tz": valueFrom(commit.author.tz),
+            "author.date": authorDate,
             "commit.hash": valueFrom(commit.hash),
             "commit.hash_short": hashShort,
             "commit.summary": valueFrom(commit.summary),
@@ -180,6 +185,7 @@ export class TextDecorator {
             "committer.name": valueFrom(commit.committer.name),
             "committer.timestamp": valueFrom(commit.committer.timestamp),
             "committer.tz": valueFrom(commit.committer.tz),
+            "committer.date": cDate,
             "time.ago": ago,
             "time.c_ago": cAgo,
             "time.from": ago,

--- a/test/suite/textdecorator.test.ts
+++ b/test/suite/textdecorator.test.ts
@@ -8,19 +8,28 @@ import {
 suite("Date Calculations", (): void => {
     test("Time ago in years", (): void => {
         assert.equal(
-            TextDecorator.toDateText(new Date(2015, 1), new Date(2014, 1)),
+            TextDecorator.toDateText(
+                new Date(2015, 1),
+                new Date(2014, 1),
+            ),
             "1 year ago",
         );
     });
 
     test("Time ago in months", (): void => {
         assert.equal(
-            TextDecorator.toDateText(new Date(2015, 4), new Date(2015, 1)),
+            TextDecorator.toDateText(
+                new Date(2015, 4),
+                new Date(2015, 1),
+            ),
             "3 months ago",
         );
 
         assert.equal(
-            TextDecorator.toDateText(new Date(2015, 2, 10), new Date(2015, 1)),
+            TextDecorator.toDateText(
+                new Date(2015, 2, 10),
+                new Date(2015, 1),
+            ),
             "1 month ago",
         );
     });


### PR DESCRIPTION
Hello there, i've implemented the date token as an alternative to `time.ago` since the date estimation is sometimes rounded and not exactly precise.

Let me know if this PR needs any extra changes.