### PR TITLE
Make gitblame.remoteName be used if unable to determine remote

### DIFF
--- a/src/git/extension.ts
+++ b/src/git/extension.ts
@@ -276,11 +276,11 @@ export class GitExtension {
             "inferCommitUrl",
         );
 
-        const remote = getRemoteUrl();
         const properties = container.resolve(Property);
+        const defaultRemoteName = properties.get("remoteName") || "origin";
+        const remote = getRemoteUrl(defaultRemoteName);
         const commitUrl = properties.get("commitUrl") || "";
-        const remoteName = properties.get("remoteName") || "origin";
-        const origin = await getOriginOfActiveFile(remoteName);
+        const origin = await getOriginOfActiveFile(defaultRemoteName);
         const projectName = this.projectNameFromOrigin(origin);
         const remoteUrl = stripGitRemoteUrl(await remote);
         const parsedUrl = TextDecorator.parseTokens(commitUrl, {

--- a/src/git/util/gitcommand.ts
+++ b/src/git/util/gitcommand.ts
@@ -63,7 +63,7 @@ export async function getOriginOfActiveFile(
     return originUrl.trim();
 }
 
-export async function getRemoteUrl(defaultRemote : string): Promise<string> {
+export async function getRemoteUrl(defaultRemote: string): Promise<string> {
     if (!validEditor(window.activeTextEditor)) {
         return "";
     }

--- a/src/git/util/gitcommand.ts
+++ b/src/git/util/gitcommand.ts
@@ -63,7 +63,7 @@ export async function getOriginOfActiveFile(
     return originUrl.trim();
 }
 
-export async function getRemoteUrl(): Promise<string> {
+export async function getRemoteUrl(defaultRemote : string): Promise<string> {
     if (!validEditor(window.activeTextEditor)) {
         return "";
     }
@@ -78,7 +78,7 @@ export async function getRemoteUrl(): Promise<string> {
     ], {
         cwd: activeFileFolder,
     });
-    const curRemote = await execute(gitCommand, [
+    var curRemote = await execute(gitCommand, [
         "config",
         "--local",
         "--get",
@@ -86,6 +86,9 @@ export async function getRemoteUrl(): Promise<string> {
     ], {
         cwd: activeFileFolder,
     });
+    if (curRemote == "") {
+        curRemote = defaultRemote;
+    }
     const remoteUrl = await execute(gitCommand, [
         "config",
         "--local",


### PR DESCRIPTION
${project.remote} will try to determine the appropriate remote based
off the current branch. This changes it to use the gitblame.remoteName
if it is unable to determine the current branch or remote.

Test: Manual.