### PR TITLE
Improve time ago estimate

### DIFF
--- a/src/util/ago.ts
+++ b/src/util/ago.ts
@@ -11,10 +11,6 @@ function unitsBetween(unit: number, now: Date, compareTo: Date): number {
     return Math.round(diffMilliseconds / unit);
 }
 
-export function secondsBetween(now: Date, compareTo: Date): number {
-    return unitsBetween(SECOND, now, compareTo);
-}
-
 export function minutesBetween(now: Date, compareTo: Date): number {
     return unitsBetween(MINUTE, now, compareTo);
 }

--- a/src/util/ago.ts
+++ b/src/util/ago.ts
@@ -5,32 +5,32 @@ const DAY = 24 * HOUR;
 const YEAR = 365.25 * DAY;
 const MONTH = YEAR / 12;
 
-function unitsBetween(unit: number, compareTo: Date, now: Date): number {
-    const diffMilliseconds = compareTo.valueOf() - now.valueOf();
+function unitsBetween(unit: number, now: Date, compareTo: Date): number {
+    const diffMilliseconds = now.valueOf() - compareTo.valueOf();
 
     return Math.round(diffMilliseconds / unit);
 }
 
-export function secondsBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(SECOND, compareTo, now);
+export function secondsBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(SECOND, now, compareTo);
 }
 
-export function minutesBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(MINUTE, compareTo, now);
+export function minutesBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(MINUTE, now, compareTo);
 }
 
-export function hoursBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(HOUR, compareTo, now);
+export function hoursBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(HOUR, now, compareTo);
 }
 
-export function daysBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(DAY, compareTo, now);
+export function daysBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(DAY, now, compareTo);
 }
 
-export function monthsBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(MONTH, compareTo, now);
+export function monthsBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(MONTH, now, compareTo);
 }
 
-export function yearsBetween(compareTo: Date, now: Date): number {
-    return unitsBetween(YEAR, compareTo, now);
+export function yearsBetween(now: Date, compareTo: Date): number {
+    return unitsBetween(YEAR, now, compareTo);
 }

--- a/src/util/textdecorator.ts
+++ b/src/util/textdecorator.ts
@@ -81,18 +81,18 @@ export class TextDecorator {
         const hours = hoursBetween(dateNow, dateThen);
         const minutes = minutesBetween(dateNow, dateThen);
 
-        if (years >= 1) {
-            return pluralText(years, "year", "years") + " ago";
-        } else if (months >= 1) {
-            return pluralText(months, "month", "months") + " ago";
-        } else if (days >= 1) {
-            return pluralText(days, "day", "days") + " ago";
-        } else if (hours >= 1) {
-            return pluralText(hours, "hour", "hours") + " ago";
-        } else if (minutes >= 5) {
-            return `${minutes} minutes ago`;
-        } else {
+        if (minutes < 5) {
             return "right now";
+        } else if (minutes < 60) {
+            return `${minutes} minutes ago`;
+        } else if (hours < 24) {
+            return pluralText(hours, "hour", "hours") + " ago";
+        } else if (days < 31) {
+            return pluralText(days, "day", "days") + " ago";
+        } else if (months < 12) {
+            return pluralText(months, "month", "months") + " ago";
+        } else {
+            return pluralText(years, "year", "years") + " ago";
         }
     }
 

--- a/test/suite/ago.test.ts
+++ b/test/suite/ago.test.ts
@@ -5,21 +5,10 @@ import {
     hoursBetween,
     minutesBetween,
     monthsBetween,
-    secondsBetween,
     yearsBetween,
 } from "../../src/util/ago";
 
 suite("Ago", (): void => {
-    test("Seconds", (): void => {
-        assert.equal(
-            secondsBetween(
-                new Date("1970-06-06 10:00:00"),
-                new Date("1970-06-06 10:00:20"),
-            ),
-            -20,
-        );
-    });
-
     test("Minutes", (): void => {
         assert.equal(
             minutesBetween(

--- a/test/suite/textdecorator.test.ts
+++ b/test/suite/textdecorator.test.ts
@@ -14,67 +14,33 @@ suite("Date Calculations", (): void => {
             ),
             "1 year ago",
         );
+        assert.equal(
+            TextDecorator.toDateText(
+                new Date(2015, 1),
+                new Date(2005, 1),
+            ),
+            "10 years ago",
+        );
     });
 
     test("Time ago in months", (): void => {
         assert.equal(
             TextDecorator.toDateText(
-                new Date(2015, 4),
                 new Date(2015, 1),
-            ),
-            "3 months ago",
-        );
-
-        assert.equal(
-            TextDecorator.toDateText(
-                new Date(2015, 2, 10),
-                new Date(2015, 1),
+                new Date(2015, 0),
             ),
             "1 month ago",
+        );
+        assert.equal(
+            TextDecorator.toDateText(
+                new Date(2015, 11, 10),
+                new Date(2015, 0),
+            ),
+            "11 months ago",
         );
     });
 
     test("Time ago in days", (): void => {
-        assert.equal(
-            TextDecorator.toDateText(
-                new Date(2015, 1, 5),
-                new Date(2015, 1, 1),
-            ),
-            "4 days ago",
-        );
-    });
-
-    test("Time ago in hours", (): void => {
-        assert.equal(
-            TextDecorator.toDateText(
-                new Date(2015, 1, 1, 3, 0, 0),
-                new Date(2015, 1, 1, 1, 0, 0),
-            ),
-            "2 hours ago",
-        );
-    });
-
-    test("Time ago in minutes", (): void => {
-        assert.equal(
-            TextDecorator.toDateText(
-                new Date(2015, 1, 1, 1, 29, 0),
-                new Date(2015, 1, 1, 1, 0, 0),
-            ),
-            "29 minutes ago",
-        );
-    });
-
-    test("Right now", (): void => {
-        assert.equal(
-            TextDecorator.toDateText(
-                new Date(2015, 1, 1, 1, 1, 0),
-                new Date(2015, 1, 1, 1, 0, 0),
-            ),
-            "right now",
-        );
-    });
-
-    test("Correct pluralisation", (): void => {
         assert.equal(
             TextDecorator.toDateText(
                 new Date(2015, 1, 2),
@@ -82,15 +48,16 @@ suite("Date Calculations", (): void => {
             ),
             "1 day ago",
         );
-
         assert.equal(
             TextDecorator.toDateText(
-                new Date(2015, 1, 3),
+                new Date(2015, 1, 31),
                 new Date(2015, 1, 1),
             ),
-            "2 days ago",
+            "30 days ago",
         );
+    });
 
+    test("Time ago in hours", (): void => {
         assert.equal(
             TextDecorator.toDateText(
                 new Date(2015, 1, 1, 1, 0, 0),
@@ -100,18 +67,44 @@ suite("Date Calculations", (): void => {
         );
         assert.equal(
             TextDecorator.toDateText(
-                new Date(2015, 1, 1, 2, 0, 0),
+                new Date(2015, 1, 1, 23, 29, 0),
                 new Date(2015, 1, 1, 0, 0, 0),
             ),
-            "2 hours ago",
+            "23 hours ago",
         );
+    });
 
+    test("Time ago in minutes", (): void => {
         assert.equal(
             TextDecorator.toDateText(
-                new Date(2015, 1, 1, 1, 6, 0),
+                new Date(2015, 1, 1, 1, 5, 0),
                 new Date(2015, 1, 1, 1, 0, 0),
             ),
-            "6 minutes ago",
+            "5 minutes ago",
+        );
+        assert.equal(
+            TextDecorator.toDateText(
+                new Date(2015, 1, 1, 1, 59, 29),
+                new Date(2015, 1, 1, 1, 0, 0),
+            ),
+            "59 minutes ago",
+        );
+    });
+
+    test("Right now", (): void => {
+        assert.equal(
+            TextDecorator.toDateText(
+                new Date(2015, 1, 1, 1, 0, 1),
+                new Date(2015, 1, 1, 1, 0, 0),
+            ),
+            "right now",
+        );
+        assert.equal(
+            TextDecorator.toDateText(
+                new Date(2015, 1, 1, 1, 4, 29),
+                new Date(2015, 1, 1, 1, 0, 0),
+            ),
+            "right now",
         );
     });
 });


### PR DESCRIPTION
### Overview

`time.ago` uses larger units of time for time differences smaller than one unit. For example, if a commit was made 7 months ago, `time.ago` reports this as "1 year ago". I think that smaller units of time would be more useful, i.e. "7 months ago".

My proposed solution is to show smaller units when they are less than their roll-over value (60 minutes, 24 hours, 31 days, or 12 months). Once the roll-over value is reached the larger unit is used. For example, 11 months is reported as "11 months ago" and 12 months is reported as "1 year ago".

### Changes made in this PR

- Use smaller units when applicable (as described above)
- Fix parameter names in ago.ts (`now` and `compareTo` were swapped)
- Remove unused `secondsBetween` function
- Cleaned up tests a bit

### Possible issue

Time differences are rounded up before they are compared to their roll-over value. For example, 11.6 months is rounded up to 12 months and is therefore reported as "1 year ago". Maybe it would be better to display this as "11 months ago" or "12 months ago". I personally prefer "1 year ago" but I'm open to other opinions.
