### PR TITLE
Add token for current line number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "gitblame",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.2.1",

--- a/src/git/util/get-tool-url.ts
+++ b/src/git/util/get-tool-url.ts
@@ -17,6 +17,7 @@ import { stripGitRemoteUrl, stripGitSuffix } from "./strip-git-remote-url";
 import { InfoTokens, parseTokens } from "../../util/textdecorator";
 import { isUncomitted } from "./uncommitted";
 import { errorMessage } from "../../util/message";
+import { getCurrentLineNumber } from "../../util/get-active";
 
 export type ToolUrlTokens = {
     "hash": string;
@@ -25,6 +26,7 @@ export type ToolUrlTokens = {
     "gitorigin.hostname": string | ((index?: string) => string | undefined);
     "gitorigin.path": string | ((index?: string) => string | undefined);
     "file.path": string;
+    "file.line": string;
 } & InfoTokens;
 
 const getDefaultToolUrl = (origin: string, commitInfo: Commit): Uri | undefined => {
@@ -89,6 +91,7 @@ export const generateUrlTokens = async (commit: Commit): Promise<[string, ToolUr
         "gitorigin.hostname": defaultPath ? gitOriginHostname(defaultPath) : "no-origin-url",
         "gitorigin.path": gitRemotePath(stripGitSuffix(origin)),
         "file.path": await getRelativePathOfActiveFile(),
+        "file.line": getCurrentLineNumber(),
     }];
 }
 

--- a/src/util/get-active.ts
+++ b/src/util/get-active.ts
@@ -1,5 +1,5 @@
 import { window } from "vscode";
-import { PartialTextEditor } from "./editorvalidator";
+import { PartialTextEditor, validEditor } from "./editorvalidator";
 
 export const getActiveTextEditor = (): PartialTextEditor | undefined => window.activeTextEditor;
 
@@ -8,3 +8,11 @@ export const NO_FILE_OR_PLACE = "N:-1";
 export const getFilePosition = (
     { document, selection }: PartialTextEditor,
 ): string => document.uri.scheme !== "file" ? NO_FILE_OR_PLACE : `${document.fileName}:${selection.active.line}`;
+
+export const getCurrentLineNumber = (): string => {
+    const activeEditor = getActiveTextEditor();
+    if (!validEditor(activeEditor)) {
+        return "0";
+    }
+    return `${activeEditor.selection.active.line}`;
+}

--- a/test/suite/generate-url-tokens.test.ts
+++ b/test/suite/generate-url-tokens.test.ts
@@ -138,7 +138,7 @@ suite("Generate URL Tokens", () => {
             },
             selection: {
                 active: {
-                    line: 1,
+                    line: 22,
                 },
             },
         });
@@ -172,6 +172,7 @@ suite("Generate URL Tokens", () => {
         assert.strictEqual(call(tokens["project.name"]), "vscode-gitblame");
         assert.strictEqual(call(tokens["project.remote"]), "github.com/Sertion/vscode-gitblame");
         assert.strictEqual(call(tokens["file.path"]), "/fake.file");
+        assert.strictEqual(call(tokens["file.line"]), "22");
     });
 
     test("ssh://git@git.company.com/project_x/test-repository.git origin", async () => {
@@ -186,7 +187,7 @@ suite("Generate URL Tokens", () => {
             },
             selection: {
                 active: {
-                    line: 1,
+                    line: 9,
                 },
             },
         });
@@ -221,5 +222,6 @@ suite("Generate URL Tokens", () => {
         assert.strictEqual(call(tokens["project.name"]), "test-repository");
         assert.strictEqual(call(tokens["project.remote"]), "git.company.com/project_x/test-repository");
         assert.strictEqual(call(tokens["file.path"]), "/fake.file");
+        assert.strictEqual(call(tokens["file.line"]), "9");
     });
 });


### PR DESCRIPTION
Added `file.line` which returns string version of line number of active editor's selection (or '0' if there is no valid editor). Useful for jumping to matching position in blame of large files.