### PR TITLE
Remove inlineBlameColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,6 @@ To enable the inline git blame view. Shows blame information at the end of the c
 
 The amount of margin between line and inline blame view
 
-### `gitblame.inlineBlameColor`
-> Type: `string`
-
-> Default value: `#888987`
-
-The inline blame view text color (as CSS Rule)
-
 ### Message Tokens
 
 | Token | Function | Parameter | Default Value | Description |


### PR DESCRIPTION
As I wanted to change the color for the inline blame text, I was trying to use the supplied setting `inlineBlameColor` in the README, but after digging into the PR, I found out that it was removed to use a more standardized way which is the `editorCodeLens.foreground` setting inside the `workbench.colorCustomizations` object.

So, I opened this PR to remove the misleading setting from the README.