### PR TITLE
add a delay before blame is shown (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ To enable the inline git blame view. Shows blame information at the end of the c
 
 The amount of margin between line and inline blame view
 
+### `gitblame.delayBlame`
+> Type: `number`
+
+> Default value: `0`
+
+This setting adds a delay (in milliseconds) before the blame is displayed
+
 ### Message Tokens
 
 | Token | Function | Parameter | Default Value | Description |

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
             "atlassian"
           ],
           "markdownDescription": "An array of substrings that, when present in the git origin URL, adds an extra _s_ to the url after _commit_ in `gitblame.commitUrl`'s default behavior"
+        },
+        "gitblame.delayBlame": {
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "This setting adds a delay (in milliseconds) before the blame is displayed"
         }
       }
     }

--- a/src/git/extension.ts
+++ b/src/git/extension.ts
@@ -154,6 +154,7 @@ export class Extension {
 
     private async updateView(
         textEditor = getActiveTextEditor(),
+        delay = getProperty("delayBlame"),
     ): Promise<void> {
         if (!validEditor(textEditor)) {
             this.view.clear();
@@ -164,6 +165,7 @@ export class Extension {
 
         const before = getFilePosition(textEditor);
         const lineAware = await this.blame.getLine(textEditor.document.fileName, textEditor.selection.active.line);
+        await new Promise((f) => setTimeout(f, delay));
         const after = getFilePosition(textEditor);
 
         // Only update if we haven't moved since we started blaming

--- a/src/util/property.ts
+++ b/src/util/property.ts
@@ -14,6 +14,7 @@ export type PropertiesMap = {
     "inlineMessageNoCommit": string;
     "inlineMessageEnabled": boolean;
     "inlineMessageMargin": number;
+    "delayBlame": number;
 }
 
 // getConfiguration has an unfortunate typing that does not


### PR DESCRIPTION
Add a setting to specify a delay before a blame is displayed. This setting is set to 0 by default.