### PR TITLE
Update remote URL parsing to support non-`git` ssh user

### DIFF
--- a/src/git/util/get-tool-url.ts
+++ b/src/git/util/get-tool-url.ts
@@ -53,7 +53,7 @@ const gitOriginHostname = ({
 export const gitRemotePath = (
 	remote: string,
 ): string | ((index?: string) => string) => {
-	if (/^[a-z]+?@/.test(remote)) {
+	if (/^[a-z0-9-]+?@/.test(remote)) {
 		const [, path] = split(remote, ":");
 		return (index = ""): string => {
 			if (index === "") {

--- a/test/suite/get-tool-url.test.ts
+++ b/test/suite/get-tool-url.test.ts
@@ -40,6 +40,14 @@ suite("Get tool URL: gitRemotePath", (): void => {
 		assert.strictEqual(call(func, "1"), "to");
 		assert.strictEqual(call(func, "2"), "something");
 	});
+	test("org-1234@", (): void => {
+		const func = gitRemotePath("org-1234@example.com:path/to/something/");
+
+		assert.strictEqual(call(func), "/path/to/something/");
+		assert.strictEqual(call(func, "0"), "path");
+		assert.strictEqual(call(func, "1"), "to");
+		assert.strictEqual(call(func, "2"), "something");
+	});
 	test("http:// with port", (): void => {
 		const func = gitRemotePath("http://example.com:8080/path/to/something/");
 


### PR DESCRIPTION
On my work device, all of our GitHub remotes are configured with remote URLs that look like `org-1234567@github.com/Org/repo.git`. This is (I believe) part of how enterprise federate access works.

As a result, the regex used to match the user section of the remote URL does not match and the URL the generated looks like `https://github.comno-remote-url/commit/{hash}`. Note the **no-remote-url** part.

The fix is to update the regex to correctly match these remote URLs. I have included that fix and a test to reproduce the issue in this PR.