### PR TITLE
fix: bundle as CJS to fix extension not loading when installed as vsix

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -3,12 +3,11 @@ import { build } from "esbuild";
 const result = await build({
 	entryPoints: ["./src/index.ts"],
 	bundle: true,
-	format: "esm",
+	format: "cjs",
 	minify: true,
 	target: "node22.22",
-	outdir: "./out/src/",
+	outfile: "./out/src/index.js",
 	metafile: !!process.env.METAFILE,
-	splitting: true,
 	external: [
 		"vscode",
 		"node:*",


### PR DESCRIPTION
esbuild was configured with format:'esm' and splitting:true, generating multiple ESM chunks. VS Code extension host loads extensions via require(), which cannot load ESM files with export statements, causing activate() to never run and the extension to hang indefinitely.

Switch to format:'cjs' with a single outfile so the bundle is loadable by the CommonJS extension host.