### PR TITLE
Add first name commit token

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,13 @@ Availiable values:
 | `${commit.hash_short,length}` | Yes      | `length`  |             7 | the first `length` characters of the 40-bit (or 64-bit) hash unique to the commit |
 | `${commit.summary}`           | Yes      | `length`  |         65536 | the first `length` characters of the first line of the commit message |
 | `${author.name}`              | No       | -         | -             | the commit author's name |
+| `${author.first_name}`        | No       | -         | -             | the commit author's first name |
 | `${author.mail}`              | No       | -         | -             | the commit author's e-mail |
 | `${author.timestamp}`         | No       | -         | -             | timestamp for the commit author's commit |
 | `${author.tz}`                | No       | -         | -             | the commit author's time zone |
 | `${author.date}`              | No       | -         | -             | the commit author's date (ex: 1990-09-16) |
 | `${committer.name}`           | No       | -         | -             | the committer's name |
+| `${committer.first_name}`     | No       | -         | -             | the committer's first name |
 | `${committer.mail}`           | No       | -         | -             | the committer's e-mail |
 | `${committer.timestamp}`      | No       | -         | -             | timestamp for the committer's commit |
 | `${committer.tz}`             | No       | -         | -             | the committer's time zone |

--- a/src/string-stuff/text-decorator.ts
+++ b/src/string-stuff/text-decorator.ts
@@ -2,6 +2,7 @@ import { between } from "../ago.js";
 import type { Commit, CommitLike } from "../git/Commit.js";
 import type { CommitAuthorLike } from "../git/CommitAuthor.js";
 import { PropertyStore } from "../PropertyStore.js";
+import { split } from "./split.js";
 
 type InfoTokenFunctionWithParameter = (value?: string) => string;
 type InfoTokenFunction = InfoTokenFunctionWithParameter | string;
@@ -13,6 +14,7 @@ export type InfoTokens = {
 export type InfoTokenNormalizedCommitInfo = {
 	"author.mail": string;
 	"author.name": string;
+	"author.first_name": string;
 	"author.timestamp": string;
 	"author.tz": string;
 	"author.date": string;
@@ -21,6 +23,7 @@ export type InfoTokenNormalizedCommitInfo = {
 	"commit.summary": InfoTokenFunctionWithParameter;
 	"committer.mail": string;
 	"committer.name": string;
+	"committer.first_name": string;
 	"committer.timestamp": string;
 	"committer.tz": string;
 	"committer.date": string;
@@ -47,12 +50,17 @@ export function normalizeCommitInfoTokens({
 		(length = ""): string => {
 			return target.slice(0, Number.parseInt(length || fallbackLength, 10));
 		};
+	const firstSplit = (target: string) => split(target)[0];
 	const currentUserAlias = PropertyStore.get("currentUserAlias");
 
 	return {
 		"author.mail": author.mail,
 		"author.name":
 			author.isCurrentUser && currentUserAlias ? currentUserAlias : author.name,
+		"author.first_name":
+			author.isCurrentUser && currentUserAlias
+				? currentUserAlias
+				: firstSplit(author.name),
 		"author.timestamp": author.timestamp,
 		"author.tz": author.tz,
 		"author.date": toIso(author),
@@ -61,6 +69,10 @@ export function normalizeCommitInfoTokens({
 			committer.isCurrentUser && currentUserAlias
 				? currentUserAlias
 				: committer.name,
+		"committer.first_name":
+			committer.isCurrentUser && currentUserAlias
+				? currentUserAlias
+				: firstSplit(committer.name),
 		"committer.timestamp": committer.timestamp,
 		"committer.tz": committer.tz,
 		"committer.date": toIso(committer),

--- a/test/suite/text-decorator.test.ts
+++ b/test/suite/text-decorator.test.ts
@@ -294,6 +294,7 @@ suite("Text Decorator with CommitInfoToken", async (): Promise<void> => {
 
 	check("committer.mail", "<torvalds@linux-foundation.org>");
 	check("committer.name", "Linus Torvalds");
+	check("committer.first_name", "Linus");
 	check("committer.tz", "-0800");
 	check("committer.date", "2015-02-13");
 
@@ -460,6 +461,13 @@ suite("Current User Replace", async (): Promise<void> => {
 				normalizedCommitInfoTokens,
 			),
 			"Blame Linus Torvalds (list_lru: introduce per-memcg lists)",
+		);
+		assert.strictEqual(
+			parseTokens(
+				"Blame ${committer.first_name} (${commit.summary})",
+				normalizedCommitInfoTokens,
+			),
+			"Blame Linus (list_lru: introduce per-memcg lists)",
 		);
 	});
 });


### PR DESCRIPTION
Adds 2 new tokens for formatting messages.

- `author.first_name`
- `committer.first_name`

Could cut down a bit on the total line length that the inline message takes up, and could be a nice-to-have for smaller teams (since others' last names are kind of redundant when you know them personally).