### PR TITLE
fix: resolve symlinked file paths before generating commit URLs (#215)

### DIFF
--- a/src/git/command/getGeneralGitInfo.ts
+++ b/src/git/command/getGeneralGitInfo.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import { getActiveTextEditor } from "../../get-active.js";
 import { validEditor } from "../../valid-editor.js";
 import { git } from "./CachedGit.js";
@@ -20,23 +21,27 @@ export async function getGeneralGitInfo(fallbackRemote: string): Promise<
 	}
 
 	const { fileName } = activeEditor.document;
+	// Resolve symlinks before handing the path to git. Opening a workspace through
+	// a symlink makes git reject the symlink path as "outside repository" (exit 128),
+	// which silently breaks URL generation. Blame already does this (see blamed-file.ts).
+	const realFileName = await realpath(fileName).catch(() => fileName);
 	const relativePathOfActiveFile = git.run(
-		fileName,
+		realFileName,
 		"ls-files",
 		"--full-name",
 		"--",
-		fileName,
+		realFileName,
 	);
-	const currentHash = git.run(fileName, "rev-parse", "HEAD");
+	const currentHash = git.run(realFileName, "rev-parse", "HEAD");
 	const currentBranch = git.run(
-		fileName,
+		realFileName,
 		"symbolic-ref",
 		"-q",
 		"--short",
 		"HEAD",
 	);
 	const currentRemote = currentBranch
-		.then((c) => git.run(fileName, "config", `branch.${c}.remote`))
+		.then((c) => git.run(realFileName, "config", `branch.${c}.remote`))
 		.then(
 			(c) => c || fallbackRemote,
 			() => fallbackRemote,
@@ -44,18 +49,18 @@ export async function getGeneralGitInfo(fallbackRemote: string): Promise<
 
 	return {
 		remoteUrl: await currentRemote
-			.then((c) => git.run(fileName, "config", `remote.${c}.url`))
+			.then((c) => git.run(realFileName, "config", `remote.${c}.url`))
 			.catch(() => ""),
 		defaultBranch: await currentBranch.then((c) =>
 			git
-				.run(fileName, "rev-parse", "--abbrev-ref", `${c}/HEAD`)
+				.run(realFileName, "rev-parse", "--abbrev-ref", `${c}/HEAD`)
 				.catch(() => "UNABLE-TO-FIND-DEFAULT-BRANCH"),
 		),
 		currentBranch: await currentBranch,
 		currentHash: await currentHash,
 		relativePathOfActiveFile: await relativePathOfActiveFile,
 		fileOrigin: await currentRemote.then((c) =>
-			git.run(fileName, "ls-remote", "--get-url", c),
+			git.run(realFileName, "ls-remote", "--get-url", c),
 		),
 	};
 }

--- a/test/suite/getGeneralGitInfo.test.ts
+++ b/test/suite/getGeneralGitInfo.test.ts
@@ -1,0 +1,92 @@
+import * as assert from "node:assert";
+import test, { afterEach, suite, type TestContext } from "node:test";
+import { setupCachedGit } from "../../src/git/command/CachedGit.js";
+import { Logger } from "../../src/logger.js";
+import { setupPropertyStore } from "../setupPropertyStore.js";
+
+const SYMLINK_PATH = "/symlink/admin-server/example.file";
+const REAL_PATH = "/real/admin-server/example.file";
+
+type ExecuteMock = Record<string, string>;
+
+const baseExecuteMock: ExecuteMock = {
+	[`ls-files --full-name -- ${REAL_PATH}`]: "example.file",
+	"rev-parse HEAD": "60d3fd32a7a9da4c8c93a9f89cfda22a0b4c65ce",
+	"symbolic-ref -q --short HEAD": "main",
+	"config branch.main.remote": "origin",
+	"config remote.origin.url": "https://github.com/Sertion/vscode-gitblame.git",
+	"rev-parse --abbrev-ref main/HEAD": "origin/main",
+	"ls-remote --get-url origin":
+		"https://github.com/Sertion/vscode-gitblame.git",
+};
+
+async function setupMocks(
+	t: TestContext,
+	executeMock: ExecuteMock,
+): Promise<{ executeCalls: string[][] }> {
+	const executeCalls: string[][] = [];
+
+	t.mock.module("node:fs/promises", {
+		namedExports: {
+			realpath: async (path: string): Promise<string> =>
+				path === SYMLINK_PATH ? REAL_PATH : path,
+		},
+	});
+	t.mock.module("../../src/get-active.js", {
+		namedExports: {
+			getActiveTextEditor: () => ({
+				document: {
+					isUntitled: false,
+					fileName: SYMLINK_PATH,
+					uri: { scheme: "file" },
+					lineCount: 1024,
+				},
+				selection: { active: { line: 1 } },
+			}),
+		},
+	});
+	t.mock.module("../../src/git/command/execute.js", {
+		namedExports: {
+			execute: async (_: Promise<string>, args: string[]): Promise<string> => {
+				executeCalls.push(args);
+				return executeMock[args.join(" ")] ?? "";
+			},
+		},
+	});
+
+	await setupCachedGit();
+	await setupPropertyStore();
+
+	return { executeCalls };
+}
+
+suite("getGeneralGitInfo with symlinked workspace path (#215)", () => {
+	Logger.createInstance();
+	afterEach(() => {
+		import("../../src/git/command/CachedGit.js").then((e) => e.git.clear());
+	});
+
+	test("runs git against the realpath, not the symlink path", async (t) => {
+		const { executeCalls } = await setupMocks(t, baseExecuteMock);
+
+		const info = await (
+			await import("../../src/git/command/getGeneralGitInfo.js")
+		).getGeneralGitInfo("origin");
+
+		assert.ok(info, "expected git info to be resolved");
+		assert.strictEqual(info.relativePathOfActiveFile, "example.file");
+
+		const lsFilesCall = executeCalls.find((args) => args[0] === "ls-files");
+		assert.ok(lsFilesCall, "expected a `git ls-files` invocation");
+		assert.strictEqual(
+			lsFilesCall.at(-1),
+			REAL_PATH,
+			"`ls-files` must receive the realpath, otherwise git rejects the symlink path as outside the repository",
+		);
+
+		assert.ok(
+			!executeCalls.some((args) => args.includes(SYMLINK_PATH)),
+			"no git command should be called with the unresolved symlink path",
+		);
+	});
+});


### PR DESCRIPTION
## Problem

Fixes #215.

When a workspace is opened through a **symlinked path** (e.g. `~/admin-server` → `~/Projects/foo/admin-server`), blame annotations display correctly, but **"View last change online"** and the status bar **"Open tool URL"** action silently do nothing — no browser tab, no error message.

## Root cause

`getGeneralGitInfo` (`src/git/command/getGeneralGitInfo.ts`) passes the active editor's raw `fileName` (the symlink path) straight to:

```
git ls-files --full-name -- <symlink path>
```

git resolves the repository at the symlink *target* but treats the symlink path as outside it, exiting `128` (`"... is outside repository at ..."`). The exception is thrown during URL-token generation, killing the action before any user-facing feedback.

Blame itself is unaffected because `src/blamed-file.ts` already resolves the real path first (`await realpath(this.filePath)`). The tool-URL path was simply missing the same step.

## Fix

Resolve the editor path with `fs.realpath` before handing it to git, mirroring `blamed-file.ts`. A `.catch(() => fileName)` fallback preserves the previous behavior if `realpath` fails (e.g. non-existent/virtual editors), so nothing regresses.

This is a single-point fix: `getGeneralGitInfo` is the only path feeding the raw editor path into git, so it covers "View last change online", "Copy tool URL", and the status-bar open action at once.

## Tests

Added `test/suite/getGeneralGitInfo.test.ts` (TDD, confirmed Red→Green): mocks `realpath` (symlink → real), points the active editor at the symlink path, and asserts git is invoked with the **real** path, never the symlink. Full suite passes (the 3 pre-existing `text-decorator` failures are timezone-dependent and unrelated to this change).